### PR TITLE
Prepare v1.0.0 release metadata

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,3 +1,20 @@
+# 2026-06-14 — v1.0.0 GA version and release docs
+- Started the `issue-16-v100-version-docs` branch for #16 under the v1.0.0 GA release issue tree.
+- Bumped the package metadata source from `1.0.0a2` to `1.0.0` in `src/fhops/__init__.py` and updated the import regression test accordingly.
+- Added final GA release notes at `docs/releases/v1.0.0.md`, carrying forward alpha highlights while separating remaining publication tasks (#17-#20).
+- Updated README and Sphinx overview install instructions to cite the stable `pip install fhops==1.0.0` path instead of release-candidate wording.
+- Corrected the release playbook so it documents Hatch dynamic versioning from `fhops.__version__`, the current command cadence, and signed `v1.0.0` tags.
+- Updated `ROADMAP.md` and `notes/release_candidate_prep.md` so the GA release docs match the active issue tree.
+- Commands executed:
+  - `git checkout -b issue-16-v100-version-docs`
+  - `.venv/bin/ruff format src tests`
+  - `.venv/bin/ruff check src tests`
+  - `.venv/bin/mypy src`
+  - `.venv/bin/pytest tests/test_import.py`
+  - `.venv/bin/pytest` *(299 passed, 210 skipped, 61 warnings)*
+  - `.venv/bin/pre-commit run --all-files`
+  - `PANDOC_DIR=$(...) PATH="$PANDOC_DIR:$PATH" .venv/bin/sphinx-build -b html docs _build/html -W`
+
 # 2026-06-14 — v1.0.0 GA preflight CI gate
 - Started the `issue-15-v100-green-ci` branch for #15 under the v1.0.0 GA release issue tree and restored the local lint/type/test gate that current `main` would hit after the existing Ruff-format failure.
 - Let Ruff normalize the pending formatting drift, including the release-blocking playback aggregate/test formatting and the processor-loader signature formatting found during the GA audit.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ forest harvesting operations plans. It provides:
 ## Installation
 
 ```bash
-pip install fhops  # once the release candidate lands on PyPI
+pip install fhops==1.0.0
 ```
 
-For local development or when cutting a release candidate, use Hatch to mirror the CI suite:
+For local development or release verification, use Hatch to mirror the CI suite:
 
 ```bash
 pip install hatch

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,7 +116,7 @@ before proposing new work.
 - [x] Complete Sphinx documentation set (API, CLI, how-tos, examples) published to Read the Docs (`notes/sphinx-documentation.md`, `docs/howto/release_playbook.rst`, `docs/howto/telemetry_ops.rst`, `docs/howto/thesis_eval.rst`, API narrative guides).
   - 2025-11-24: Closed the Sphinx/docstring audit (feature/api-docstring-enhancements) — all CLI, evaluation, heuristics, and productivity modules now ship NumPy-style docstrings and Sphinx builds are warning-free.
 - [x] Finalise contribution guide, code of conduct alignment, and PR templates (see `docs/howto/release_playbook.rst`, `CONTRIBUTING.md`, `AGENTS.md`).
-- [x] Versioned release notes and public roadmap updates (`docs/releases/v1.0.0-alpha1.md`, `docs/releases/v0.1.0.md`, `ROADMAP.md` current).
+- [x] Versioned release notes and public roadmap updates (`docs/releases/v1.0.0.md`, `docs/releases/v1.0.0-alpha2.md`, `docs/releases/v1.0.0-alpha1.md`, `docs/releases/v0.1.0.md`, `ROADMAP.md` current).
 - [ ] Outreach plan (blog, seminars, partner briefings).
 
 ## Phase 5 — Formal Model Documentation Synchronization
@@ -129,6 +129,7 @@ before proposing new work.
 1. **Release Candidate Prep (`notes/release_candidate_prep.md`, `AGENTS.md`, `notes/cli_docs_plan.md`)**
    - Lock feature set, refresh install/docs, and draft release notes + Hatch-based packaging checklist ahead of the public milestone.
    - 2026-06-14: v1.0.0 GA issue tree opened; first child branch (`issue-15-v100-green-ci`) is restoring the green CI/local verification gate before release metadata changes.
+   - 2026-06-14: second child branch (`issue-16-v100-version-docs`) bumps package metadata/docs to the final `1.0.0` release line before artifact and publication work.
 2. **Metaheuristic Roadmap (`notes/metaheuristic_roadmap.md`)**
    - Prioritise SA refinements, operator registry work, and benchmarking comparisons with the new harness (including shift-aware neighbourhoods).
 3. **Shift-Based Scheduling Refactor (`notes/modular_reorg_plan.md`, `notes/mip_model_plan.md`, `notes/simulation_eval_plan.md`)**

--- a/docs/howto/release_playbook.rst
+++ b/docs/howto/release_playbook.rst
@@ -16,8 +16,12 @@ Release Preparation
 
 2. **Version & Changelog**
 
-   - Bump the version string in ``pyproject.toml`` (``[project].version``) and ensure the same value
-     appears in ``src/fhops/__init__.py`` if applicable.
+   - Bump the version string in ``src/fhops/__init__.py``. FHOPS uses Hatch dynamic
+     versioning (``[tool.hatch.version]`` in ``pyproject.toml``), so the package
+     version is read from ``fhops.__version__`` rather than a static
+     ``[project].version`` field.
+   - Update ``tests/test_import.py`` and the current release note under
+     ``docs/releases/`` to match the version string.
    - Append a new section to ``CHANGE_LOG.md`` summarising the release (date, highlights, command
      suite used for verification). Remember: the pre-commit hook enforces that the changelog is
      touched in every PR.
@@ -28,7 +32,7 @@ Release Preparation
 
      .. code-block:: bash
 
-        sphinx-build -b html docs docs/_build/html
+        sphinx-build -b html docs _build/html -W
 
    - Execute the weekly telemetry workflow (from :doc:`telemetry_ops`) so the latest notebook and
      tuning history are published before tagging.
@@ -36,22 +40,23 @@ Release Preparation
 
 4. **Testing**
 
-- Run the required command suite (per ``AGENTS.md``):
+   - Run the required command suite (per ``AGENTS.md``):
 
      .. code-block:: bash
 
         pip install -e .[dev]
-        ruff format src tests docs
-        ruff check src tests docs
+        ruff format src tests
+        ruff check src tests
         mypy src
         pytest
         pre-commit run --all-files
+        sphinx-build -b html docs _build/html -W
 
    - Optional: execute ``scripts/run_analytics_notebooks.py --light`` as a final smoke test.
 
 5. **Tag & Publish**
 
-   - Once tests/docs pass, create a tag (e.g., ``git tag v0.1.0``) and push both branch + tag.
+   - Once tests/docs pass, create a tag (e.g., ``git tag -s v1.0.0``) and push both branch + tag.
    - Build artifacts with ``hatch build`` and upload using Twine (keeps PyPI auth simple):
 
      .. code-block:: bash

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -34,9 +34,9 @@ Automation pipeline
 Installation
 ------------
 
-FHOPS publishes wheels/sdists via Hatch. Once the release candidate is on PyPI, install with::
+FHOPS publishes wheels/sdists via Hatch. Install the stable v1.0.0 release with::
 
-   pip install fhops
+   pip install fhops==1.0.0
 
 For development or release verification, install Hatch and run the full suite locally::
 

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -1,0 +1,42 @@
+# FHOPS v1.0.0
+
+## Summary
+- Promotes FHOPS out of the alpha line for SoftwareX submission and public reuse.
+- Builds on the `v1.0.0-alpha2` documentation and CLI reliability work, plus the post-alpha rolling-horizon planning, operational MILP formulation synchronization, SoftwareX automation assets, refreshed examples, and telemetry reporting updates now present on `main`.
+- Restores the full CI/release preflight gate before the final version bump: Ruff format/check, MyPy, pytest, pre-commit, telemetry smoke reporting, light analytics notebooks, and Sphinx docs are green on the release-prep branch.
+- Keeps package artifacts private-data conscious: wheels exclude `notes/`, while source distributions retain public docs/examples needed for source-level reproducibility.
+
+## Installation
+```bash
+pip install fhops==1.0.0
+
+# Development / verification
+pip install hatch
+hatch run dev:suite
+```
+
+## Highlights
+- **Stable public release** - `fhops.__version__` now reports `1.0.0`, giving SoftwareX reviewers and downstream users a non-prerelease package to install and cite.
+- **Release gate restored** - Current Ruff, MyPy, pytest, pre-commit, telemetry smoke, light notebook, and Sphinx gates pass before publication work begins.
+- **SoftwareX-ready documentation base** - The docs include synchronized operational formulation material, manuscript asset references, telemetry dashboards, and reproducibility playbooks.
+- **Planning and telemetry maturity** - Rolling-horizon planning APIs, benchmark/tuning reports, playback summaries, and analytics notebooks are available in the public documentation set.
+
+## Migration Notes
+- Users on `1.0.0a1` or `1.0.0a2` can upgrade with `pip install --upgrade fhops==1.0.0`.
+- Scenario files continue to use schema version `1.0.0`; existing alpha-era scenario bundles remain compatible unless they relied on private planning notes excluded from package artifacts.
+- Optional extras remain unchanged: use `fhops[geo]` for geospatial dependencies and `fhops[gurobi]` for Gurobi-backed MIP runs.
+
+## Known Issues / Next Steps
+- SoftwareX manuscript metadata and in-repo manuscript prose still need to be aligned to the final public release under issue #17.
+- Package artifact inspection and smoke installs are tracked under issue #18 before upload.
+- Public release surfaces, including GitHub release cleanup and Pages verification, are tracked under issue #19.
+- TestPyPI/PyPI upload, final tag, and GitHub release publication are tracked under issue #20.
+
+## Verification
+- `ruff format src tests`
+- `ruff check src tests`
+- `mypy src`
+- `pytest`
+- `pre-commit run --all-files`
+- `sphinx-build -b html docs _build/html -W`
+- Tag-build, TestPyPI/PyPI upload, and clean-install smoke tests are completed during the final publication issue.

--- a/notes/release_candidate_prep.md
+++ b/notes/release_candidate_prep.md
@@ -15,6 +15,9 @@ Status: Active — v1.0.0 GA preflight in progress for SoftwareX submission.
    - [x] Add ``hatch.toml``/pyproject updates (build-system, project metadata, scripts, dependencies).
    - [x] Define version source (pyproject now uses ``[tool.hatch.version]`` pointing at ``src/fhops/__init__.__version__``; bump workflow = edit that constant + changelog).
    - [x] Configure Hatch environments/custom commands for lint/test/release parity with ws3.
+   - [x] Bump final GA version metadata to ``1.0.0`` for SoftwareX submission.
+     - 2026-06-14: issue #16 updates ``src/fhops/__init__.py``, ``tests/test_import.py``,
+       final release notes, README/overview install wording, and the release playbook.
 2. **Packaging QA**
    - [x] ``hatch build`` wheel/sdist locally and inspect contents (license, data files, examples).
      - Built `dist/fhops-0.0.2*` via `hatch build`; artifacts include CLI entry points and docs assets.
@@ -29,6 +32,7 @@ Status: Active — v1.0.0 GA preflight in progress for SoftwareX submission.
    - [x] Summarise Phase 1-3 achievements, telemetry tooling, and new CLI surfaces (see `notes/release_notes_draft.md`).
    - [x] Document breaking changes and migration guidance (schema version, mobilisation config).
    - [x] Add "Known Issues / Next" section pointing to backlog items (agentic tuner, DSS hooks).
+   - [x] Publish final GA notes at ``docs/releases/v1.0.0.md``.
 5. **Hyperparameter tuning sign-off**
    - [x] Re-run the tuning harness (baseline bundles) with the latest code; see `notes/release_tuning_results.md` and `tmp/release-tuning/` artifacts.
    - [x] Document the improvements (objective delta, runtime, win rate) in release notes and telemetry dashboards.
@@ -40,6 +44,7 @@ Status: Active — v1.0.0 GA preflight in progress for SoftwareX submission.
      - 2026-06-14: issue #15 branch fixes current Ruff formatting drift, modernises `StrEnum`
        lint blockers, and hardens tuner-report subprocess tests so the local lint/type/test gate
        can pass under the release verification environment.
+     - 2026-06-14: issue #15 merged via PR #21 after full CI success.
 
 7. **Publishing (TestPyPI → PyPI)**
    - [x] Dry run using TestPyPI:

--- a/src/fhops/__init__.py
+++ b/src/fhops/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.0.0a2"
+__version__ = "1.0.0"

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,4 +1,4 @@
 def test_import():
     import fhops
 
-    assert fhops.__version__ == "1.0.0a2"
+    assert fhops.__version__ == "1.0.0"


### PR DESCRIPTION
## Summary
- bump `fhops.__version__` and the import regression from `1.0.0a2` to final `1.0.0`
- add final `docs/releases/v1.0.0.md` with migration notes and remaining publication blockers
- update README/overview installation guidance to stable `pip install fhops==1.0.0` wording
- correct the release playbook to describe Hatch dynamic versioning from `src/fhops/__init__.py`
- update roadmap and release-prep notes for the GA issue tree

Closes #16.

## Verification
- `.venv/bin/ruff format src tests`
- `.venv/bin/ruff check src tests`
- `.venv/bin/mypy src`
- `.venv/bin/pytest tests/test_import.py`
- `.venv/bin/pytest`
- `.venv/bin/pre-commit run --all-files`
- `PANDOC_DIR=$(...) PATH="$PANDOC_DIR:$PATH" .venv/bin/sphinx-build -b html docs _build/html -W`

Full pytest result: 299 passed, 210 skipped, 61 warnings.