### PR TITLE
Audit v1.0.0 release surfaces

### DIFF
--- a/.github/workflows/analytics-notebooks.yml
+++ b/.github/workflows/analytics-notebooks.yml
@@ -73,19 +73,36 @@ jobs:
 
       - name: Collect notebook artefacts
         run: |
+          set -euo pipefail
           timestamp="$(date -u +"%Y-%m-%dT%H%M%SZ")"
           out_dir="tmp/analytics-notebooks"
           history_root="$out_dir/history"
           run_dir="$history_root/$timestamp"
+          metadata_file="docs/examples/analytics/data/notebook_metadata.json"
+
+          if [ ! -s "$metadata_file" ]; then
+            echo "::error file=$metadata_file::Notebook metadata was not produced by scripts/run_analytics_notebooks.py"
+            find docs/examples/analytics/data -maxdepth 2 -type f | sort || true
+            exit 1
+          fi
+
           mkdir -p "$run_dir"
-          cp docs/examples/analytics/data/notebook_metadata.json "$out_dir/notebook_metadata_latest.json"
-          cp docs/examples/analytics/data/notebook_metadata.json "$run_dir/notebook_metadata.json"
+          cp "$metadata_file" "$out_dir/notebook_metadata_latest.json"
+          cp "$metadata_file" "$run_dir/notebook_metadata.json"
           tar -czf "$run_dir/notebooks.tar.gz" docs/examples/analytics/*.ipynb
           if [ -d "$history_root" ]; then
-            cd "$history_root"
-            ls -1 | sort | head -n -4 | xargs -r -d '\n' rm -rf
+            python - "$history_root" <<'PY'
+          import shutil
+          import sys
+          from pathlib import Path
+
+          history_root = Path(sys.argv[1])
+          runs = sorted(path for path in history_root.iterdir() if path.is_dir())
+          for stale_run in runs[:-4]:
+              shutil.rmtree(stale_run)
+          PY
           fi
-          ls -R "$out_dir"
+          find "$out_dir" -maxdepth 4 -type f | sort
 
       - name: Upload full notebook artefacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -28,7 +28,7 @@ jobs:
           pip install hatch
 
       - name: Build package
-        run: hatch run release:build
+        run: hatch clean && hatch build
 
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ instead of suppressing them; escalate only if consensus is reached with maintain
   applicable). Version source lives at `src/fhops/__init__.__version__` (pyproject uses Hatch's
   dynamic version hook). Document the exact commands in the changelog.
 - GitHub Actions workflow `.github/workflows/release-build.yml` mirrors this process on tags by
-  running `hatch run release:build` and uploading `dist/` artifacts; verify the job succeeds before
+  running `hatch clean && hatch build` and uploading `dist/` artifacts; verify the job succeeds before
   publishing to TestPyPI/PyPI.
 - TestPyPI/PyPI publishing cadence:
   1. `hatch clean && hatch build`

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,3 +1,46 @@
+# 2026-06-14 — v1.0.0 release surface audit
+- Started the `issue-19-release-surface-audit` branch for #19 under the v1.0.0 GA release issue tree.
+- Audited GitHub releases, tags, release-build runs, Pages configuration, current CI state, and repeated full analytics notebook failures before final publication.
+- Recorded the public release-surface findings and release-day checklist in `notes/release_surface_audit.md`.
+- Chose to annotate the confusing `v0.0.1-alpha3` prerelease instead of deleting historical GitHub release/tag artifacts before GA publication.
+- Triggered the manual `Release Build Verification` workflow against `main` to validate the current tag-build path without creating a throwaway tag; the run exposed the same `hatch run release:build` failure as `v0.0.1-alpha3`.
+- Fixed `.github/workflows/release-build.yml` to run `hatch clean && hatch build` directly, matching the release playbook and successful local artifact-smoke commands; the corrected branch workflow-dispatch run succeeded and uploaded `dist/` artifacts.
+- Hardened the weekly full analytics artifact collection step so missing notebook metadata fails with an explicit diagnostic and retained history pruning no longer depends on shell pipeline edge cases.
+- Updated `AGENTS.md`, `ROADMAP.md`, `notes/release_candidate_prep.md`, `notes/release_notes_draft.md`, and `notes/metaheuristic_hyperparam_tuning.md` with the issue #19 audit status.
+- Commands executed:
+  - `git checkout main && git pull --ff-only && git checkout -b issue-19-release-surface-audit`
+  - `gh release list --limit 20`
+  - `gh api repos/UBC-FRESH/fhops/pages --jq '{status: .status, html_url: .html_url, source: .source, build_type: .build_type, public: .public}'`
+  - `gh run list --limit 30 --json databaseId,workflowName,displayTitle,status,conclusion,createdAt,headBranch,event,url`
+  - `git tag --sort=-creatordate | sed -n '1,30p' && git show-ref --tags | sed -n '1,80p'`
+  - `gh run view 24542056488 --json name,displayTitle,event,headBranch,conclusion,createdAt,url,jobs`
+  - `gh run view 22052621554 --json name,displayTitle,event,headBranch,conclusion,createdAt,url,jobs`
+  - `gh issue view 19 --json number,title,state,body,url,labels`
+  - `gh release view v0.0.1-alpha3 --json tagName,name,isDraft,isPrerelease,publishedAt,targetCommitish,body,url && gh release view v0.0.2 --json tagName,name,isDraft,isPrerelease,publishedAt,targetCommitish,body,url`
+  - `gh api repos/UBC-FRESH/fhops/releases/latest --jq '{tag_name: .tag_name, name: .name, prerelease: .prerelease, draft: .draft, published_at: .published_at, html_url: .html_url}'`
+  - `git show --no-patch --format='v0.0.1-alpha3 %H %ad %s' --date=iso-strict v0.0.1-alpha3 && git show --no-patch --format='v0.0.2 %H %ad %s' --date=iso-strict v0.0.2 && git show v0.0.1-alpha3:src/fhops/__init__.py | sed -n '1,40p'`
+  - `gh run list --workflow 'Release Build Verification' --limit 10 --json databaseId,displayTitle,status,conclusion,createdAt,headBranch,event,url`
+  - `gh run view 22052621554 --job 63713682709 --log | sed -n '/Collect notebook artefacts/,/Upload full notebook artefacts/p'` (failed because GitHub returned HTTP 410 for expired logs)
+  - `gh workflow run release-build.yml --ref main && sleep 3 && gh run list --workflow 'Release Build Verification' --limit 3 --json databaseId,displayTitle,status,conclusion,createdAt,headBranch,event,url`
+  - `gh run view 27511910006 --job 81313421305 --log | sed -n '/Build package/,/Upload dist artifacts/p'`
+  - `tmpfile=$(mktemp); printf '%s\n\n' '> **Release-surface note (2026-06-14):** This prerelease is retained for provenance only. It is superseded by the v1.0.0 GA release-preparation path; the tagged source still reports the alpha package line (\`fhops.__version__ = "1.0.0a2"\`) and should not be treated as the current stable FHOPS release.' > "$tmpfile"; gh release view v0.0.1-alpha3 --json body --jq .body >> "$tmpfile"; gh release edit v0.0.1-alpha3 --notes-file "$tmpfile"; rm "$tmpfile"; gh release view v0.0.1-alpha3 --json body --jq .body | sed -n '1,12p'`
+  - `.venv/bin/hatch clean && .venv/bin/hatch build`
+  - `.venv/bin/ruff format src tests`
+  - `.venv/bin/ruff check src tests`
+  - `.venv/bin/mypy src`
+  - `.venv/bin/pytest` (301 passed, 210 skipped, 61 warnings)
+  - `.venv/bin/pre-commit run --all-files`
+  - `PANDOC_DIR=$(.venv/bin/python - <<'PY'
+from pathlib import Path
+import pypandoc
+print(Path(pypandoc.get_pandoc_path()).parent)
+PY
+); PATH="$PANDOC_DIR:$PATH" .venv/bin/sphinx-build -b html docs _build/html -W`
+  - `.venv/bin/pre-commit run --all-files` (rerun after changelog update)
+  - `git push -u origin issue-19-release-surface-audit`
+  - `gh workflow run release-build.yml --ref issue-19-release-surface-audit && sleep 5 && gh run list --workflow 'Release Build Verification' --branch issue-19-release-surface-audit --limit 3 --json databaseId,displayTitle,status,conclusion,createdAt,headBranch,event,url`
+  - `sleep 20 && gh run view 27512093324 --json status,conclusion,url,jobs`
+
 # 2026-06-14 — v1.0.0 artifact smoke install and package data audit
 - Started the `issue-18-v100-artifact-smoke` branch for #18 under the v1.0.0 GA release issue tree.
 - Rebuilt final `fhops-1.0.0` sdist/wheel artifacts and audited archive contents before publication.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -132,6 +132,7 @@ before proposing new work.
    - 2026-06-14: second child branch (`issue-16-v100-version-docs`) bumps package metadata/docs to the final `1.0.0` release line before artifact and publication work.
    - 2026-06-14: third child branch (`issue-17-softwarex-v100-metadata`) aligns in-repo SoftwareX manuscript metadata/prose with the final `v1.0.0` release links and install path.
    - 2026-06-14: fourth child branch (`issue-18-v100-artifact-smoke`) validates final `1.0.0` artifacts, fixes clean wheel runtime dependencies/package data, moves the full-text reference-document vault to a private `reference-documents` submodule for copyright-risk control, and records the public-bibliography vs. private-source-document content policy.
+   - 2026-06-14: fifth child branch (`issue-19-release-surface-audit`) audits public release surfaces, annotates the confusing `v0.0.1-alpha3` prerelease, fixes the manual release-build path, and hardens the full analytics notebook artifact workflow before the final publication issue.
 2. **Metaheuristic Roadmap (`notes/metaheuristic_roadmap.md`)**
    - Prioritise SA refinements, operator registry work, and benchmarking comparisons with the new harness (including shift-aware neighbourhoods).
 3. **Shift-Based Scheduling Refactor (`notes/modular_reorg_plan.md`, `notes/mip_model_plan.md`, `notes/simulation_eval_plan.md`)**

--- a/notes/metaheuristic_hyperparam_tuning.md
+++ b/notes/metaheuristic_hyperparam_tuning.md
@@ -216,6 +216,12 @@ Status: paused until the conventional tuning toolkit, benchmarking automation, a
   3. Executes `scripts/run_analytics_notebooks.py --timeout 900 --keep-going` (no `--light`).
   4. Archives notebook metadata + rendered notebooks under `tmp/analytics-notebooks/history/<timestamp>/` (GH artifact `analytics-notebooks-full`, retention 28 days).
   5. Rebuilds Sphinx docs + telemetry bundle and deploys GitHub Pages (telemetry dashboards + `telemetry/notebooks/` history).
+- 2026-06-14 release-surface audit: repeated scheduled failures reached notebook execution
+  and then failed while collecting artifacts; old detailed logs have expired. The artifact
+  collection step now validates that notebook metadata exists, prints explicit diagnostics
+  when it is missing, and prunes retained run history via Python instead of shell pipeline
+  edge cases. Run the workflow manually after this lands before claiming a fresh full
+  dashboard refresh for v1.0.0.
 - **Ownership & escalation**
   - Rotation: assign quarterly owners (track here + `notes/team_ops.md`). Owner checks workflow Tuesday morning and responds to failures within 12 h.
   - Notification: TODO — add Slack/Email webhook for workflow failures (placeholder: manual checks).

--- a/notes/release_candidate_prep.md
+++ b/notes/release_candidate_prep.md
@@ -57,11 +57,17 @@ Status: Active — v1.0.0 GA preflight in progress for SoftwareX submission.
 6. **Automation**
    - [x] Add GitHub Actions job template for ``hatch build`` verification (triggered on tags) — see `.github/workflows/release-build.yml`.
    - [x] Prepare release checklist in ``AGENTS.md`` (Hatch build/publish cadence documented under Release workflow).
-   - [ ] Restore green `main` CI before the v1.0.0 version bump/tag.
+   - [x] Restore green `main` CI before the v1.0.0 version bump/tag.
      - 2026-06-14: issue #15 branch fixes current Ruff formatting drift, modernises `StrEnum`
        lint blockers, and hardens tuner-report subprocess tests so the local lint/type/test gate
        can pass under the release verification environment.
      - 2026-06-14: issue #15 merged via PR #21 after full CI success.
+   - [ ] Clean up release automation and public surfaces before the final tag.
+     - 2026-06-14: issue #19 records the release-surface audit in
+       `notes/release_surface_audit.md`, annotates the confusing `v0.0.1-alpha3` prerelease
+       instead of deleting history, fixes the release-build workflow command exposed by
+       `workflow_dispatch`, and hardens full analytics artifact collection before a fresh
+       manual dashboard run.
 
 7. **Publishing (TestPyPI → PyPI)**
    - [x] Dry run using TestPyPI:

--- a/notes/release_notes_draft.md
+++ b/notes/release_notes_draft.md
@@ -10,7 +10,7 @@
 
 ## Installation
 - `pip install fhops` (PyPI)
-- Development/release verification via Hatch: `hatch run dev:suite`, `hatch run release:build`.
+- Development/release verification via Hatch: `hatch run dev:suite`, `hatch clean && hatch build`.
 
 ## Breaking Changes / Migration
 - Scenario files must declare `schema_version` and can optionally include GeoJSON references (`scenario.geo` / mobilisation config) for auto-loaded distances.

--- a/notes/release_surface_audit.md
+++ b/notes/release_surface_audit.md
@@ -1,0 +1,61 @@
+# v1.0.0 Release Surface Audit
+
+Date: 2026-06-14
+Status: Active - issue #19, under the v1.0.0 GA release issue tree.
+
+## Scope
+
+This note tracks the public surfaces that could make the FHOPS v1.0.0 release look stale,
+accidental, or still prerelease-only to SoftwareX reviewers and users.
+
+## Findings
+
+- GitHub's latest stable release currently resolves to `v0.0.2`, published 2025-11-10.
+- `v0.0.1-alpha3` is a newer GitHub prerelease, published 2026-04-17 from `main`, but the
+  tagged source still reports `fhops.__version__ = "1.0.0a2"`. Its release notes compare
+  `v1.0.0-alpha2...v0.0.1-alpha3`, which makes it look like a confused prerelease rather
+  than a stable milestone.
+- The `v0.0.1-alpha3` tag and a 2026-06-14 manual `workflow_dispatch` run both exposed the
+  same release-build failure: the workflow called `hatch run release:build`, but `hatch build`
+  cannot run inside a normal Hatch environment. The workflow should call `hatch clean &&
+  hatch build` directly, matching the release playbook and successful local artifact-smoke
+  commands.
+- After correcting the workflow command on `issue-19-release-surface-audit`, manual
+  `Release Build Verification` run `27512093324` succeeded and uploaded `dist/` artifacts.
+- GitHub Pages is in workflow deployment mode and serves `https://ubc-fresh.github.io/fhops/`.
+  The Pages API still reports `feature/towards-phase3-milestone` as its stored source
+  branch, but current CI deploys the Pages artifact from `main` only through the
+  `deploy-pages` action.
+- The weekly `Analytics Notebooks (Full)` workflow has repeated scheduled failures on
+  `main`; the last visible failure reached `Execute analytics notebooks (full)` and then
+  failed at `Collect notebook artefacts`. GitHub's detailed logs for that February 2026 run
+  have expired, so the exact shell line cannot be recovered.
+
+## Decisions
+
+- Keep `v0.0.1-alpha3` in place instead of deleting the tag or release before GA. It is a
+  prerelease, not the latest stable release, and deleting historical release artifacts
+  creates avoidable provenance churn during manuscript submission. Add a public release
+  note annotation that it is superseded by the v1.0.0 GA path.
+- Treat the stale Pages source branch as non-blocking while Pages remains in workflow
+  deployment mode. The release blocker is the actual deployed artifact from `main`, not the
+  legacy source-field label.
+- Harden the full analytics artifact collection step now, then treat a fresh manual full
+  analytics run as the release readiness check. A failed full analytics run should not block
+  PyPI publication if the standard CI light notebooks and Sphinx build pass, but it should
+  block any claim that the telemetry dashboards are freshly regenerated.
+
+## Release-Day Checklist
+
+- [x] Confirm a manual `Release Build Verification` workflow run succeeds after the workflow
+  command is corrected.
+- [ ] Re-run or confirm `Release Build Verification` on `main` after this branch merges and
+  before the signed `v1.0.0` tag is created.
+- [ ] Confirm the current `main` CI run succeeds and deploys the Pages artifact.
+- [ ] Trigger `Analytics Notebooks (Full)` manually after this workflow hardening lands; if it
+  fails again, open a follow-up with the fresh run URL and exclude "fresh full dashboard
+  refresh" from the v1.0.0 claims.
+- [ ] Confirm the GitHub release created for `v1.0.0` is non-prerelease and becomes the latest
+  stable GitHub release.
+- [ ] Confirm PyPI serves `fhops==1.0.0` and that the install snippet in README/docs matches
+  the published package.


### PR DESCRIPTION
## Summary
- Audit v1.0.0 public release surfaces in `notes/release_surface_audit.md`.
- Annotate the confusing `v0.0.1-alpha3` prerelease as superseded instead of deleting historical release/tag artifacts.
- Fix `Release Build Verification` to run `hatch clean && hatch build` directly; branch workflow-dispatch run `27512093324` now succeeds and uploads artifacts.
- Harden weekly full analytics notebook artifact collection with explicit metadata diagnostics and Python-based history pruning.

## Testing
- `.venv/bin/hatch clean && .venv/bin/hatch build`
- `.venv/bin/ruff format src tests`
- `.venv/bin/ruff check src tests`
- `.venv/bin/mypy src`
- `.venv/bin/pytest` (301 passed, 210 skipped, 61 warnings)
- `.venv/bin/pre-commit run --all-files`
- `PANDOC_DIR=... PATH="$PANDOC_DIR:$PATH" .venv/bin/sphinx-build -b html docs _build/html -W`
- `gh workflow run release-build.yml --ref issue-19-release-surface-audit` -> success, run `27512093324`

Addresses #19.
