### PR TITLE
Sync v1.0.0 post-release state

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,3 +1,30 @@
+# 2026-06-15 — v1.0.0 post-release housekeeping
+- Started the `issue-post-v100-release-housekeeping` branch for #29 after completing the v1.0.0 publication issue tree.
+- Updated `docs/releases/v1.0.0.md` so the published release notes no longer describe #20 or #27 as pending follow-ups.
+- Marked `notes/release_candidate_prep.md` complete for GA publication and recorded the TestPyPI/PyPI/tag/GitHub release outcome.
+- Converted `notes/release_surface_audit.md` from active pre-release audit wording to a final release-surface outcome note, while leaving the full analytics notebook refresh as a separate non-blocking follow-up.
+- Added a `ROADMAP.md` closure entry for issue #20 and the completed v1.0.0 GA issue tree.
+- Commands executed:
+  - `git status --short --branch --untracked-files=no`
+  - `sed -n '1,220p' AGENTS.md`
+  - `sed -n '1,130p' notes/release_candidate_prep.md`
+  - `sed -n '1,140p' notes/release_surface_audit.md`
+  - `git checkout main && git pull --ff-only && git checkout -b issue-post-v100-release-housekeeping && gh issue create --title "Post-release: sync docs and planning state after v1.0.0 publication" --body-file -`
+  - `sed -n '1,90p' CHANGE_LOG.md`
+  - `sed -n '124,142p' ROADMAP.md`
+  - `tail -40 notes/coding-agent-conversation-log.txt 2>/dev/null || true`
+  - `sed -n '1,80p' docs/releases/v1.0.0.md`
+  - `rg -n "currently resolves|signed \`v1\\.0\\.0\`|#20 or #27 as pending|TestPyPI/PyPI upload, final tag|Final user-facing documentation readiness|Status: Active|After TestPyPI validation" docs/releases/v1.0.0.md notes/release_candidate_prep.md notes/release_surface_audit.md ROADMAP.md CHANGE_LOG.md || true`
+  - `git diff --check`
+  - `.venv/bin/ruff format src tests`
+  - `.venv/bin/ruff check src tests`
+  - `.venv/bin/mypy src`
+  - `.venv/bin/pytest` (301 passed, 210 skipped, 61 warnings)
+  - `.venv/bin/pre-commit run --all-files`
+  - `PATH="/home/gep/projects/fhops/tmp/pandoc-bin:$PATH" .venv/bin/sphinx-build -b html docs _build/html -W`
+  - `gh release edit v1.0.0 --notes-file docs/releases/v1.0.0.md`
+  - `rm -rf _build && .venv/bin/pre-commit run --all-files && git diff --check && git status --short`
+
 # 2026-06-14 — v1.0.0 user-facing documentation readiness sweep
 - Started the `issue-27-docs-readiness` branch for #27 under the v1.0.0 GA release issue tree.
 - Fixed README rendering by closing the development-install code block before the optional Gurobi setup.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -134,6 +134,7 @@ before proposing new work.
    - 2026-06-14: fourth child branch (`issue-18-v100-artifact-smoke`) validates final `1.0.0` artifacts, fixes clean wheel runtime dependencies/package data, moves the full-text reference-document vault to a private `reference-documents` submodule for copyright-risk control, and records the public-bibliography vs. private-source-document content policy.
    - 2026-06-14: fifth child branch (`issue-19-release-surface-audit`) audits public release surfaces, annotates the confusing `v0.0.1-alpha3` prerelease, fixes the manual release-build path, and hardens the full analytics notebook artifact workflow before the final publication issue.
    - 2026-06-14: sixth child branch (`issue-27-docs-readiness`) sweeps user-facing docs before publication, fixing broken README rendering, stale CLI examples, source-checkout/PyPI wording, and release-note status.
+   - 2026-06-15: issue #20 closes the v1.0.0 GA tree by publishing `fhops==1.0.0` to TestPyPI/PyPI, pushing the annotated `v1.0.0` tag, verifying the tag-triggered release-build workflow, and creating the public non-prerelease GitHub release.
 2. **Metaheuristic Roadmap (`notes/metaheuristic_roadmap.md`)**
    - Prioritise SA refinements, operator registry work, and benchmarking comparisons with the new harness (including shift-aware neighbourhoods).
 3. **Shift-Based Scheduling Refactor (`notes/modular_reorg_plan.md`, `notes/mip_model_plan.md`, `notes/simulation_eval_plan.md`)**

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -17,7 +17,7 @@ hatch run dev:suite
 
 ## Highlights
 - **Stable public release** - `fhops.__version__` now reports `1.0.0`, giving SoftwareX reviewers and downstream users a non-prerelease package to install and cite.
-- **Release gate restored** - Current Ruff, MyPy, pytest, pre-commit, telemetry smoke, light notebook, and Sphinx gates pass before publication work begins.
+- **Release gate restored** - Current Ruff, MyPy, pytest, pre-commit, telemetry smoke, light notebook, tag-build, and Sphinx gates passed for publication.
 - **SoftwareX-ready documentation base** - The docs include synchronized operational formulation material, manuscript asset references, telemetry dashboards, and reproducibility playbooks.
 - **Planning and telemetry maturity** - Rolling-horizon planning APIs, benchmark/tuning reports, playback summaries, and analytics notebooks are available in the public documentation set.
 
@@ -27,8 +27,8 @@ hatch run dev:suite
 - Optional extras remain unchanged: use `fhops[geo]` for geospatial dependencies and `fhops[gurobi]` for Gurobi-backed MIP runs.
 
 ## Known Issues / Next Steps
-- Final user-facing documentation readiness is tracked under issue #27.
-- TestPyPI/PyPI upload, final tag, and GitHub release publication are tracked under issue #20.
+- The v1.0.0 GA readiness issue tree is complete: #15, #16, #17, #18, #19, #20, and #27 are closed.
+- Historical reference-document blob cleanup remains deferred until after SoftwareX submission under issue #25.
 
 ## Verification
 - `ruff format src tests`
@@ -37,4 +37,8 @@ hatch run dev:suite
 - `pytest`
 - `pre-commit run --all-files`
 - `sphinx-build -b html docs _build/html -W`
-- Tag-build, TestPyPI/PyPI upload, and clean-install smoke tests are completed during the final publication issue.
+- `hatch clean && hatch build`
+- `twine check dist/*`
+- TestPyPI upload and clean install smoke for `fhops==1.0.0`
+- PyPI upload and clean install smoke for `fhops==1.0.0`
+- Tag-triggered `Release Build Verification` workflow run for `v1.0.0`

--- a/notes/release_candidate_prep.md
+++ b/notes/release_candidate_prep.md
@@ -1,13 +1,13 @@
 # Release Candidate Prep Plan
 
 Date: 2025-11-16
-Status: Active — v1.0.0 GA preflight in progress for SoftwareX submission.
+Status: Complete — v1.0.0 GA was published on 2026-06-15 for SoftwareX submission.
 
 ## Objectives
 - Freeze scope and polish docs/install instructions for the first FHOPS release candidate.
 - Adopt Hatch for packaging/publishing (mirroring ws3 workflows) and ensure PyPI metadata is accurate.
 - Produce changelog/release notes, version bumps, and verification checklists before tagging.
-- Promote the public package from the current `1.0.0a2` prerelease line to a clean `1.0.0`
+- Promote the public package from the `1.0.0a2` prerelease line to a clean `1.0.0`
   GA release that SoftwareX reviewers can install and cite.
 
 ## Tasks
@@ -62,17 +62,22 @@ Status: Active — v1.0.0 GA preflight in progress for SoftwareX submission.
        lint blockers, and hardens tuner-report subprocess tests so the local lint/type/test gate
        can pass under the release verification environment.
      - 2026-06-14: issue #15 merged via PR #21 after full CI success.
-   - [ ] Clean up release automation and public surfaces before the final tag.
+   - [x] Clean up release automation and public surfaces before the final tag.
      - 2026-06-14: issue #19 records the release-surface audit in
        `notes/release_surface_audit.md`, annotates the confusing `v0.0.1-alpha3` prerelease
        instead of deleting history, fixes the release-build workflow command exposed by
        `workflow_dispatch`, and hardens full analytics artifact collection before a fresh
        manual dashboard run.
-   - [ ] Sweep user-facing documentation before final publication.
+   - [x] Sweep user-facing documentation before final publication.
      - 2026-06-14: issue #27 records the public-docs readiness sweep in
        `notes/docs_readiness_sweep.md`, fixes README rendering, corrects stale
        `fhops evaluate` / `fhops eval-playback` examples, clarifies source-checkout vs.
        PyPI-installed content, and updates v1.0.0 release-note status.
+   - [x] Publish the final `v1.0.0` tag and GitHub release.
+     - 2026-06-15: issue #20 publishes `fhops==1.0.0` to TestPyPI and PyPI, verifies
+       clean installs from both indexes, pushes the annotated `v1.0.0` tag, verifies
+       tag-triggered release-build run `27517181902`, and creates the public
+       non-prerelease GitHub release.
 
 7. **Publishing (TestPyPI → PyPI)**
    - [x] Dry run using TestPyPI:
@@ -81,7 +86,9 @@ Status: Active — v1.0.0 GA preflight in progress for SoftwareX submission.
      - ``python -m venv .venv-testpypi && . .venv-testpypi/bin/activate``
      - ``pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple fhops`` and run smoke commands (`fhops --help`, `fhops validate examples/tiny7/scenario.yaml`) ✅
    - [x] Document environment variables/secrets: PyPI tokens stored via ``~/.pypirc`` or passed directly to ``twine upload`` (see AGENTS.md Release workflow).
-   - [ ] After TestPyPI validation, repeat for PyPI using Twine during the release tag: ``python -m twine upload -u __token__ -p 'pypi-…' dist/*``.
+   - [x] After TestPyPI validation, repeat for PyPI using Twine during the release tag.
+     - 2026-06-15: TestPyPI and PyPI both report `fhops` latest as `1.0.0`; clean
+       install smoke tests from both indexes printed `fhops.__version__ == "1.0.0"`.
 
 ## References
 - ws3 Hatch workflow: https://github.com/ubc-fresh/ws3

--- a/notes/release_surface_audit.md
+++ b/notes/release_surface_audit.md
@@ -1,16 +1,20 @@
 # v1.0.0 Release Surface Audit
 
 Date: 2026-06-14
-Status: Active - issue #19, under the v1.0.0 GA release issue tree.
+Status: Complete - issue #19 closed, with final release-surface verification completed
+under issue #20 on 2026-06-15.
 
 ## Scope
 
-This note tracks the public surfaces that could make the FHOPS v1.0.0 release look stale,
-accidental, or still prerelease-only to SoftwareX reviewers and users.
+This note tracked the public surfaces that could make the FHOPS v1.0.0 release look stale,
+accidental, or still prerelease-only to SoftwareX reviewers and users. The final release
+surface is now stable: PyPI/TestPyPI serve `fhops==1.0.0`, the public GitHub release is
+non-prerelease, and the tag-triggered release-build workflow passed.
 
 ## Findings
 
-- GitHub's latest stable release currently resolves to `v0.0.2`, published 2025-11-10.
+- Before GA publication, GitHub's latest stable release resolved to `v0.0.2`, published
+  2025-11-10.
 - `v0.0.1-alpha3` is a newer GitHub prerelease, published 2026-04-17 from `main`, but the
   tagged source still reports `fhops.__version__ = "1.0.0a2"`. Its release notes compare
   `v1.0.0-alpha2...v0.0.1-alpha3`, which makes it look like a confused prerelease rather
@@ -31,6 +35,17 @@ accidental, or still prerelease-only to SoftwareX reviewers and users.
   failed at `Collect notebook artefacts`. GitHub's detailed logs for that February 2026 run
   have expired, so the exact shell line cannot be recovered.
 
+## Final Outcome
+
+- `v1.0.0` was published on 2026-06-15 from `main` commit
+  `d98fd104e69686ba4498d6628b646f210d7b9af1`.
+- PyPI and TestPyPI both report `fhops` latest as `1.0.0`, and clean install smoke tests
+  from both indexes printed `fhops.__version__ == "1.0.0"`.
+- The GitHub release `FHOPS v1.0.0` is public, non-draft, and non-prerelease.
+- The tag-triggered `Release Build Verification` workflow passed in run `27517181902`.
+- The `v1.0.0` tag is annotated rather than GPG-signed because the release environment
+  had no GPG secret key or signing configuration available.
+
 ## Decisions
 
 - Keep `v0.0.1-alpha3` in place instead of deleting the tag or release before GA. It is a
@@ -49,13 +64,13 @@ accidental, or still prerelease-only to SoftwareX reviewers and users.
 
 - [x] Confirm a manual `Release Build Verification` workflow run succeeds after the workflow
   command is corrected.
-- [ ] Re-run or confirm `Release Build Verification` on `main` after this branch merges and
-  before the signed `v1.0.0` tag is created.
-- [ ] Confirm the current `main` CI run succeeds and deploys the Pages artifact.
+- [x] Re-run or confirm `Release Build Verification` on `main` after this branch merges and
+  before the annotated `v1.0.0` tag is created.
+- [x] Confirm the current `main` CI run succeeds and deploys the Pages artifact.
 - [ ] Trigger `Analytics Notebooks (Full)` manually after this workflow hardening lands; if it
   fails again, open a follow-up with the fresh run URL and exclude "fresh full dashboard
   refresh" from the v1.0.0 claims.
-- [ ] Confirm the GitHub release created for `v1.0.0` is non-prerelease and becomes the latest
+- [x] Confirm the GitHub release created for `v1.0.0` is non-prerelease and becomes the latest
   stable GitHub release.
-- [ ] Confirm PyPI serves `fhops==1.0.0` and that the install snippet in README/docs matches
+- [x] Confirm PyPI serves `fhops==1.0.0` and that the install snippet in README/docs matches
   the published package.


### PR DESCRIPTION
## Summary
- update v1.0.0 release notes so #20/#27 are no longer described as pending
- mark the release candidate prep note complete after TestPyPI/PyPI/tag/GitHub publication
- convert the release surface audit to a final outcome note and add the roadmap closure line
- sync the public GitHub release notes from `docs/releases/v1.0.0.md`

Closes #29.

## Validation
- `.venv/bin/ruff format src tests`
- `.venv/bin/ruff check src tests`
- `.venv/bin/mypy src`
- `.venv/bin/pytest` (301 passed, 210 skipped, 61 warnings)
- `.venv/bin/pre-commit run --all-files`
- `PATH="/home/gep/projects/fhops/tmp/pandoc-bin:$PATH" .venv/bin/sphinx-build -b html docs _build/html -W`
